### PR TITLE
Switch to Python 3.10.0 and pandas 1.3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Select base-image
-FROM python:3.10.0-slim-bullseye
+FROM python:3.9.9-slim-bullseye
 
 # Load python requirements, install them and clean up.
 COPY requirements.txt /
-RUN pip3 install -r requirements.txt --no-cache-dir && rm requirements.txt
+RUN pip3 install --upgrade pip && pip3 install -r requirements.txt --no-cache-dir && rm requirements.txt
 
 # Copy required files into container
 COPY forecast_parser.py ksql-config.json gridpoints.csv /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Select base-image
-FROM python:3.9.9-slim-bullseye
+FROM python:3.10.0-slim-bullseye
 
 # Load python requirements, install them and clean up.
 COPY requirements.txt /

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 kafka-python==2.0.2
-pandas==1.1.5
-requests==2.20.0
+pandas==1.3.5
+requests==2.26.0


### PR DESCRIPTION
Officially pandas 1.3.5 does not support python 3.10, but it has been working fine, so will not downgrade.
Pandas 1.3.5 works fine with install. requests updated to version 1.26.0 as it is the newest and does not break.