### PR TITLE
Fix NaN bug for ENet-files

### DIFF
--- a/app/forecast_parser.py
+++ b/app/forecast_parser.py
@@ -84,7 +84,7 @@ def extract_forecast(filepath: str, field_dict: dict):
     df_all.reset_index(level='location', inplace=True)
     df_all['estim_time'] = calculation_time
     df_all['estim_file'] = filename
-    return df_all
+    return df_all.fillna(0)
 
 
 def publish_forecast(producer: KafkaProducer, df: dict, kafka_topic: str, location_lookup: dict):

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 name: forecast-parser
 description: A Helm chart for energinet-singularity/forecast-parser
-version: 1.1.2
+version: 1.1.3
 
 dependencies:
   - name: file-mover
     repository: "https://energinet-singularity.github.io/helm-registry/"
-    version: 1.1.1
+    version: 1.1.2

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/energinet-singularity/forecast-parser/energinet-singularity/forecast-parser
   pullPolicy: IfNotPresent
-  tag: "1.1.2"
+  tag: "1.1.3"
 
 #Setup file-mover dependency first
 forecastInputVolume: 


### PR DESCRIPTION
Both Enet and ENet files gave a NaN for radiation values. These must be replaced by 0 to have kafka accept the input.